### PR TITLE
Fix duplicate UDF conversion definition

### DIFF
--- a/gui_converter.py
+++ b/gui_converter.py
@@ -160,13 +160,7 @@ def convert_office_to_pdf(file_path):
         log(f"[HATA] {e}")
 
 
-def convert_udf_to_pdf(file_path):
-    try:
-        base = os.path.splitext(os.path.basename(file_path))[0]
-        output_file = os.path.join(output_dir, f"{base}.pdf")
-        log("[UYARI] UDF dosyası PDF'e dönüştürme desteği henüz entegre edilmedi.")
-    except Exception as e:
-        log(f"[HATA] {e}")
+
 
 
 def select_file():


### PR DESCRIPTION
## Summary
- remove the duplicate placeholder `convert_udf_to_pdf`
- keep the earlier detailed version so UDF conversion works

## Testing
- `python3 -m py_compile gui_converter.py`

------
https://chatgpt.com/codex/tasks/task_e_684005d481a0832b8941864d609b39fa